### PR TITLE
Point custom backup methods docs to the backup_method hook's

### DIFF
--- a/pages/02.administer/20.backups/30.custom_backup_methods/custom_backup_methods.md
+++ b/pages/02.administer/20.backups/30.custom_backup_methods/custom_backup_methods.md
@@ -18,7 +18,9 @@ This operation is done with a hook and will allow you to launch a backup this wa
 yunohost backup create --method custom
 ```
 
-Below is a simplistic example that can be used to set up a rotational backup with different disks that are changed every week:
+See the [`backup_method` hook documentation](/packaging_apps_hooks#backup-method) for more details on the script's arguments.
+
+Below is a simplistic hook script example that can be used to set up a rotational backup with different disks that are changed every week:
 
 `/etc/yunohost/hooks.d/backup_method/05-custom`
 


### PR DESCRIPTION
The custom backup methods docs provide an example script, mentioning "hook", but AFAIU, hooks should be familiar only to contributors / app packagers.

As the hook's docs provide a bit more details on arguments passed to the script, I guess a pointer won't harm, then
